### PR TITLE
Feature: Add TestExecution type

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -11,8 +11,14 @@ generates:
       contextType: ../../context#Context
       rootValueType: unknown
       immutableTypes: true
-      makeResolverTypeCallable: false
+      makeResolverTypeCallable: true
       optionalInfoArgument: true
+      onlyResolveTypeForInterfaces: true
+      strictScalars: true
+      scalars:
+        DateTime: Date
+      mappers:
+        TestExecution: ./mappers#TestExecutionModel
     plugins:
       - typescript
       - typescript-resolvers

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "dependencies": {
         "@apollo/server": "^4.3.2",
         "@as-integrations/aws-lambda": "^2.0.0",
+        "graphql-date-scalars": "^0.2.0",
         "zod": "^3.20.2"
       },
       "devDependencies": {
@@ -4339,6 +4340,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/graphql-date-scalars": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/graphql-date-scalars/-/graphql-date-scalars-0.2.0.tgz",
+      "integrity": "sha512-eMslPwX8jZOe+FQaxWulRq5KfiVUzu6pZmYwxg7gv/CCuyDYM9yyuRCMmIL1SX1mabp3vwOE+WYnDCYY17Nx5A==",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/graphql-request": {
@@ -10096,6 +10108,12 @@
           }
         }
       }
+    },
+    "graphql-date-scalars": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/graphql-date-scalars/-/graphql-date-scalars-0.2.0.tgz",
+      "integrity": "sha512-eMslPwX8jZOe+FQaxWulRq5KfiVUzu6pZmYwxg7gv/CCuyDYM9yyuRCMmIL1SX1mabp3vwOE+WYnDCYY17Nx5A==",
+      "requires": {}
     },
     "graphql-request": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@apollo/server": "^4.3.2",
     "@as-integrations/aws-lambda": "^2.0.0",
+    "graphql-date-scalars": "^0.2.0",
     "zod": "^3.20.2"
   },
   "scripts": {

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,1 +1,9 @@
-export type Context = {};
+import { createDataSources, DataSources } from './datasources/index.js';
+
+export type Context = {
+    dataSources: DataSources;
+};
+
+export const createContext = async (): Promise<Context> => ({
+    dataSources: createDataSources(),
+});

--- a/src/datasources/TestExecution.ts
+++ b/src/datasources/TestExecution.ts
@@ -1,0 +1,13 @@
+export class TestExecution {
+    getById(id: string) {
+        if (id === '1234') {
+            return {
+                id: '1234',
+                at: new Date('2023-02-07T15:22:40.909Z'),
+                until: new Date('2023-02-07T15:22:54.348Z'),
+            };
+        }
+
+        return null;
+    }
+}

--- a/src/datasources/index.ts
+++ b/src/datasources/index.ts
@@ -1,0 +1,7 @@
+import { TestExecution } from './TestExecution.js';
+
+export const createDataSources = () => ({
+    testExecution: new TestExecution(),
+});
+
+export type DataSources = ReturnType<typeof createDataSources>;

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -1,13 +1,12 @@
 import { startStandaloneServer } from '@apollo/server/standalone';
 import config from './config.js';
+import { createContext } from './context.js';
 import server from './server.js';
 
 const { url } = await startStandaloneServer(
     server,
     {
-        async context() {
-            return {};
-        },
+        context: createContext,
         listen: {
             port: config.PORT,
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,14 +2,13 @@ import {
     startServerAndCreateLambdaHandler,
     handlers,
 } from '@as-integrations/aws-lambda';
+import { createContext } from './context.js';
 import server from './server.js';
 
 export const graphqlHandler = startServerAndCreateLambdaHandler(
     server,
     handlers.createAPIGatewayProxyEventRequestHandler(),
     {
-        async context() {
-            return {};
-        },
+        context: createContext,
     },
 );

--- a/src/resolvers/Query.ts
+++ b/src/resolvers/Query.ts
@@ -1,7 +1,36 @@
-import { QueryResolvers } from './types/generated';
+import { decodeId, decodeIdForType } from '../util/id.js';
+import { QueryResolvers } from './types/generated.js';
 
 const resolvers: QueryResolvers = {
     test: () => true,
+    async testExecution(root, { id }, { dataSources }) {
+        const decodedId = decodeIdForType('TestExecution', id);
+        if (!decodedId) {
+            return null;
+        }
+        const testExecution = await dataSources.testExecution.getById(decodedId);
+        if (!testExecution) {
+            return null;
+        }
+        return {
+            __typename: 'TestExecution',
+            id: testExecution.id,
+        };
+    },
+    async node(root, { id }, context, info) {
+        const decodedId = decodeId(id);
+        if (!decodedId) {
+            return null;
+        }
+        const [typename, _internalId] = decodedId;
+
+        switch (typename) {
+            case 'TestExecution':
+                return resolvers.testExecution(root, { id }, context, info);
+            default:
+                return null;
+        }
+    },
 };
 
 export default resolvers;

--- a/src/resolvers/TestExecution.ts
+++ b/src/resolvers/TestExecution.ts
@@ -1,0 +1,19 @@
+import { assertNonNull } from '../util/assertNonNull.js';
+import { encodeId } from '../util/id.js';
+import { TestExecutionResolvers } from './types/generated.js';
+
+const resolvers: TestExecutionResolvers = {
+    async at({ id }, _args, { dataSources }) {
+        const testExecution = assertNonNull(await dataSources.testExecution.getById(id));
+        return testExecution.at;
+    },
+    id({ id }) {
+        return encodeId('TestExecution', id);
+    },
+    async until({ id }, _args, { dataSources }) {
+        const testExecution = assertNonNull(await dataSources.testExecution.getById(id));
+        return testExecution.until;
+    },
+}
+
+export default resolvers;

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,7 +1,23 @@
+import { DateTimeScalar } from 'graphql-date-scalars';
 import { Resolvers } from './types/generated.js';
 import Query from './Query.js'
+import TestExecution from './TestExecution.js';
+
+const interfaceResolvers = {
+    __resolveType<T extends String>(parent: { __typename: T }): T {
+        return parent.__typename;
+    }
+}
 
 const resolvers: Resolvers = {
+    DateTime: DateTimeScalar,
+    Event: interfaceResolvers,
+    InstantaneousEvent: {
+        __resolveType: () => null,
+    },
+    IntervalEvent: interfaceResolvers,
+    Node: interfaceResolvers,
+    TestExecution,
     Query,
 }
 

--- a/src/resolvers/types/generated.ts
+++ b/src/resolvers/types/generated.ts
@@ -1,10 +1,12 @@
-import { GraphQLResolveInfo } from 'graphql';
+import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
+import { TestExecutionModel } from './mappers';
 import { Context } from '../../context';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type RequireFields<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -12,22 +14,61 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  /** Represents a DateTime in ISO8601 format. */
+  DateTime: Date;
+};
+
+export type Event = {
+  readonly at: Scalars['DateTime'];
+};
+
+export type InstantaneousEvent = {
+  readonly at: Scalars['DateTime'];
+};
+
+export type IntervalEvent = {
+  readonly at: Scalars['DateTime'];
+  readonly until: Scalars['DateTime'];
+};
+
+/**
+ * Represents a Node according to the Global Object Identification spec.
+ *
+ * See https://graphql.org/learn/global-object-identification/
+ */
+export type Node = {
+  readonly id: Scalars['ID'];
 };
 
 export type Query = {
   readonly __typename?: 'Query';
+  readonly node: Maybe<Node>;
   readonly test: Scalars['Boolean'];
+  readonly testExecution: Maybe<TestExecution>;
+};
+
+
+export type QueryNodeArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type QueryTestExecutionArgs = {
+  id: Scalars['ID'];
+};
+
+export type TestExecution = Event & IntervalEvent & Node & {
+  readonly __typename?: 'TestExecution';
+  readonly at: Scalars['DateTime'];
+  readonly id: Scalars['ID'];
+  readonly until: Scalars['DateTime'];
 };
 
 
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
 
-
-export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
-  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
-};
-export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> = ResolverFn<TResult, TParent, TContext, TArgs> | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> = ResolverFn<TResult, TParent, TContext, TArgs>;
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
@@ -89,22 +130,71 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+  DateTime: ResolverTypeWrapper<Scalars['DateTime']>;
+  Event: ResolversTypes['TestExecution'];
+  ID: ResolverTypeWrapper<Scalars['ID']>;
+  InstantaneousEvent: never;
+  IntervalEvent: ResolversTypes['TestExecution'];
+  Node: ResolversTypes['TestExecution'];
   Query: ResolverTypeWrapper<unknown>;
   String: ResolverTypeWrapper<Scalars['String']>;
+  TestExecution: ResolverTypeWrapper<TestExecutionModel>;
 };
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
   Boolean: Scalars['Boolean'];
+  DateTime: Scalars['DateTime'];
+  Event: ResolversParentTypes['TestExecution'];
+  ID: Scalars['ID'];
+  InstantaneousEvent: never;
+  IntervalEvent: ResolversParentTypes['TestExecution'];
+  Node: ResolversParentTypes['TestExecution'];
   Query: unknown;
   String: Scalars['String'];
+  TestExecution: TestExecutionModel;
+};
+
+export interface DateTimeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
+  name: 'DateTime';
+}
+
+export type EventResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Event'] = ResolversParentTypes['Event']> = {
+  __resolveType: TypeResolveFn<'TestExecution', ParentType, ContextType>;
+};
+
+export type InstantaneousEventResolvers<ContextType = Context, ParentType extends ResolversParentTypes['InstantaneousEvent'] = ResolversParentTypes['InstantaneousEvent']> = {
+  __resolveType: TypeResolveFn<null, ParentType, ContextType>;
+};
+
+export type IntervalEventResolvers<ContextType = Context, ParentType extends ResolversParentTypes['IntervalEvent'] = ResolversParentTypes['IntervalEvent']> = {
+  __resolveType: TypeResolveFn<'TestExecution', ParentType, ContextType>;
+};
+
+export type NodeResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
+  __resolveType: TypeResolveFn<'TestExecution', ParentType, ContextType>;
 };
 
 export type QueryResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
+  node: Resolver<Maybe<ResolversTypes['Node']>, ParentType, ContextType, RequireFields<QueryNodeArgs, 'id'>>;
   test: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  testExecution: Resolver<Maybe<ResolversTypes['TestExecution']>, ParentType, ContextType, RequireFields<QueryTestExecutionArgs, 'id'>>;
+};
+
+export type TestExecutionResolvers<ContextType = Context, ParentType extends ResolversParentTypes['TestExecution'] = ResolversParentTypes['TestExecution']> = {
+  at: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  id: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  until: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type Resolvers<ContextType = Context> = {
+  DateTime: GraphQLScalarType;
+  Event: EventResolvers<ContextType>;
+  InstantaneousEvent: InstantaneousEventResolvers<ContextType>;
+  IntervalEvent: IntervalEventResolvers<ContextType>;
+  Node: NodeResolvers<ContextType>;
   Query: QueryResolvers<ContextType>;
+  TestExecution: TestExecutionResolvers<ContextType>;
 };
 

--- a/src/resolvers/types/mappers.ts
+++ b/src/resolvers/types/mappers.ts
@@ -1,0 +1,4 @@
+export interface TestExecutionModel {
+    __typename: 'TestExecution',
+    id: string,
+}

--- a/src/schema/execution/TestExecution.graphql
+++ b/src/schema/execution/TestExecution.graphql
@@ -1,0 +1,9 @@
+type TestExecution implements Node & Event & IntervalEvent {
+    id: ID!
+    at: DateTime!
+    until: DateTime!
+}
+
+extend type Query {
+    testExecution(id: ID!): TestExecution
+}

--- a/src/schema/interfaces/Event.graphql
+++ b/src/schema/interfaces/Event.graphql
@@ -1,0 +1,12 @@
+interface Event {
+    at: DateTime!
+}
+
+interface InstantaneousEvent implements Event {
+    at: DateTime!
+}
+
+interface IntervalEvent implements Event {
+    at: DateTime!
+    until: DateTime!
+}

--- a/src/schema/interfaces/Node.graphql
+++ b/src/schema/interfaces/Node.graphql
@@ -1,0 +1,12 @@
+"""
+    Represents a Node according to the Global Object Identification spec.
+
+    See https://graphql.org/learn/global-object-identification/
+"""
+interface Node {
+    id: ID!
+}
+
+extend type Query {
+    node(id: ID!): Node
+}

--- a/src/schema/scalars.graphql
+++ b/src/schema/scalars.graphql
@@ -1,0 +1,4 @@
+"""
+    Represents a DateTime in ISO8601 format.
+"""
+scalar DateTime

--- a/src/util/assertNonNull.ts
+++ b/src/util/assertNonNull.ts
@@ -1,0 +1,6 @@
+export const assertNonNull = <T>(input: T | null): T => {
+    if (input === null) {
+        throw new Error('Expected value to be non-null.');
+    }
+    return input;
+}

--- a/src/util/id.ts
+++ b/src/util/id.ts
@@ -1,0 +1,33 @@
+const separator = '/';
+const base64Regex = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+export const encodeId = (typename: string, internalId: string): string => {
+    return Buffer.from(`${typename}${separator}${internalId}`, 'utf-8').toString('base64');
+}
+
+export const decodeId = (id: string): [string, string] | null => {
+    if (!base64Regex.test(id)) {
+        return null;
+    }
+    const unobfuscated = Buffer.from(id, 'base64').toString('utf-8');
+    const separatorIndex = unobfuscated.indexOf(separator);
+    if (separatorIndex === -1) {
+        return null;
+    }
+
+    const typename = unobfuscated.substring(0, separatorIndex);
+    const internalId = unobfuscated.substring(separatorIndex + 1);
+    return [typename, internalId];
+}
+
+export const decodeIdForType = (typename: string, id: string): string | null => {
+    const decodedId = decodeId(id);
+    if (!decodedId) {
+        return null;
+    }
+    const [decodedTypename, internalId] = decodedId;
+    if (decodedTypename !== typename) {
+        return null;
+    }
+    return internalId;
+}


### PR DESCRIPTION
Makes the following query work:
```graphql
query {
  node(id: "VGVzdEV4ZWN1dGlvbi8xMjM0") {
    ... on TestExecution {
      id
      at
      until
    }
  }
  testExecution(id: "VGVzdEV4ZWN1dGlvbi8xMjM0") {
    id
    at
    until
  }
}
```

```json
{
  "data": {
    "node": {
      "id": "VGVzdEV4ZWN1dGlvbi8xMjM0",
      "at": "2023-02-07T15:22:40.909Z",
      "until": "2023-02-07T15:22:54.348Z"
    },
    "testExecution": {
      "id": "VGVzdEV4ZWN1dGlvbi8xMjM0",
      "at": "2023-02-07T15:22:40.909Z",
      "until": "2023-02-07T15:22:54.348Z"
    }
  }
}
```