### PR TITLE
[Fix] We should not expect a cypress command to always have a parent

### DIFF
--- a/src/maps/mapSteps.ts
+++ b/src/maps/mapSteps.ts
@@ -65,22 +65,14 @@ const mapSteps = (steps: unknown, testExecutionId: string, endedTestsAt: Date) =
         if(command.state === 'failed'){
             step.status = CommandEventStatus.Failed;
         }
-        if (item.type === 'parent') {
-            if(step.commandChains.length){
-                const lastCommandChain = step.commandChains[step.commandChains.length - 1]
-                lastCommandChain.until = at
-            }
-            step.commandChains.push({
-                __typename: 'CommandChainEvent',
-                at,
-                until,
-                id: `${testExecutionId}/commandChain/${i + 1}`,
-                commands: [command],
-            })
-            continue;
-        }
-
-        step.commandChains[step.commandChains.length - 1].commands.push(command);
+        
+        step.commandChains.push({
+            __typename: 'CommandChainEvent',
+            at,
+            until,
+            id: `${testExecutionId}/commandChain/${i + 1}`,
+            commands: [command],
+        });
     }
 
     mappedSteps[mappedSteps.length - 1].until = endedTestsAt


### PR DESCRIPTION
Bug fix for: https://trello.com/c/ZtHg3t3O/292-bug-we-should-not-expect-a-cypress-command-to-always-have-a-parent

Removed check for parent type commands in `mapSteps.ts`.

![image](https://github.com/testerloop/testerloop-server/assets/4661986/c680a70c-bc16-4f59-928b-dcf11898c570)

