### PR TITLE
[HOTFIX] Path for TestExecutionScreenshot

### DIFF
--- a/src/datasources/ConsoleEvent/index.ts
+++ b/src/datasources/ConsoleEvent/index.ts
@@ -14,7 +14,7 @@ export class ConsoleEvent {
     logByTestExecutionIdDataLoader = new DataLoader<string, Record<string, Log>>(
         (ids) => Promise.all(ids.map(async (testExecutionId) => {
             const bucketName = config.AWS_BUCKET_NAME;
-             const bucketPath = config.AWS_BUCKET_PATH || '';
+            const bucketPath = config.AWS_BUCKET_PATH || '';
             const json = await S3Service.getObject(bucketName, `${bucketPath}${testExecutionId}/console/console-logs.json`);
             const parsed = parseLogFile(json);
             return Object.fromEntries(

--- a/src/datasources/NetworkEvent.ts
+++ b/src/datasources/NetworkEvent.ts
@@ -14,7 +14,7 @@ export class NetworkEvent {
     networkEventsByTestExecutionIdDataLoader = new DataLoader<string, ReturnType<typeof mapNetworkEvents>>(
         (ids) => Promise.all(ids.map(async (testExecutionId) => {
             const bucketName = config.AWS_BUCKET_NAME;
-             const bucketPath = config.AWS_BUCKET_PATH || '';
+            const bucketPath = config.AWS_BUCKET_PATH || '';
             const events = await S3Service.getObject(bucketName, `${bucketPath}${testExecutionId}/har/network-events.har`);
             const mappedEvents = mapNetworkEvents(events, testExecutionId);
 

--- a/src/datasources/Screenshot.ts
+++ b/src/datasources/Screenshot.ts
@@ -14,7 +14,7 @@ export class Screenshot {
     screenshotByTestExecutionIdDataLoader = new DataLoader<string, ReturnType<typeof mapScreenshots>>(
         (ids) => Promise.all(ids.map(async (testExecutionId) => {
             const bucketName = config.AWS_BUCKET_NAME;
-             const bucketPath = config.AWS_BUCKET_PATH || '';
+            const bucketPath = config.AWS_BUCKET_PATH || '';
             const screenshots = await S3Service.listObjects(bucketName, `${bucketPath}${testExecutionId}/screenshots/`);
             return mapScreenshots(screenshots, testExecutionId)
         }))

--- a/src/datasources/Snapshot.ts
+++ b/src/datasources/Snapshot.ts
@@ -14,7 +14,7 @@ export class Snapshot {
     snapshotByTestExecutionIdDataLoader = new DataLoader<string, ReturnType<typeof mapSnapshots>>(
         (ids) => Promise.all(ids.map(async (testExecutionId) => {
             const bucketName = config.AWS_BUCKET_NAME;
-             const bucketPath = config.AWS_BUCKET_PATH || '';
+            const bucketPath = config.AWS_BUCKET_PATH || '';
             const snapshots = await S3Service.getObject(bucketName, `${bucketPath}${testExecutionId}/snapshots/snapshot-metadata.json`);
             const mappedSnapshots = mapSnapshots(snapshots, testExecutionId);
             return mappedSnapshots;

--- a/src/datasources/StepEvent.ts
+++ b/src/datasources/StepEvent.ts
@@ -14,7 +14,7 @@ export class StepEvent {
     stepByTestExecutionIdDataLoader = new DataLoader<string, ReturnType<typeof mapSteps>>(
         (ids) => Promise.all(ids.map(async (testExecutionId) => {
             const bucketName = config.AWS_BUCKET_NAME;
-             const bucketPath = config.AWS_BUCKET_PATH || '';
+            const bucketPath = config.AWS_BUCKET_PATH || '';
             const [steps, results] = await Promise.all([
                 S3Service.getObject(bucketName, `${bucketPath}${testExecutionId}/cypress/out.json`),
                 this.context.dataSources.testResults.getResultsByTestExecutionId(testExecutionId),

--- a/src/datasources/TestCodeRevision.ts
+++ b/src/datasources/TestCodeRevision.ts
@@ -36,7 +36,7 @@ export class TestCodeRevision {
     cicdDataByRunIdDataLoader = new DataLoader<string, Cicd>(
         (ids) => Promise.all(ids.map(async (runId) => {
             const bucketName = config.AWS_BUCKET_NAME;
-             const bucketPath = config.AWS_BUCKET_PATH || '';
+            const bucketPath = config.AWS_BUCKET_PATH || '';
             const cicdRaw = await S3Service.getObject(bucketName, `${bucketPath}${runId}/logs/cicd.json`)
             const cicd = CicdSchema.parse(cicdRaw);
             return cicd;

--- a/src/datasources/TestExecution.ts
+++ b/src/datasources/TestExecution.ts
@@ -15,7 +15,7 @@ export class TestExecution {
         first?: number | null, after?: string | null;
     }) {
         const bucketName = config.AWS_BUCKET_NAME;
-         const bucketPath = config.AWS_BUCKET_PATH || '';
+        const bucketPath = config.AWS_BUCKET_PATH || '';
         const results = await S3Service.listSubFolders(bucketName, `${bucketPath}${id}/`);
 
         const testExecutionIds = results
@@ -29,7 +29,7 @@ export class TestExecution {
 
     async getById(id: string) {
         const bucketName = config.AWS_BUCKET_NAME;
-         const bucketPath = config.AWS_BUCKET_PATH || '';
+        const bucketPath = config.AWS_BUCKET_PATH || '';
         const [runId, requestId] = id.split('/');
         const results = await S3Service.getObject(bucketName, `${bucketPath}${runId}/${requestId}/cypress/results.json`) as {startedTestsAt: string, endedTestsAt: string};
 

--- a/src/datasources/TestResults.ts
+++ b/src/datasources/TestResults.ts
@@ -32,7 +32,7 @@ export class TestResults {
     resultsByTestExecutionIdDataLoader = new DataLoader<string, Results>(
         (ids) => Promise.all(ids.map(async (testExecutionId) => {
             const bucketName = config.AWS_BUCKET_NAME;
-             const bucketPath = config.AWS_BUCKET_PATH || '';
+            const bucketPath = config.AWS_BUCKET_PATH || '';
             const rawResults = await S3Service.getObject(bucketName, `${bucketPath}${testExecutionId}/cypress/results.json`)
             const results = ResultsSchema.parse(rawResults);
             return results;

--- a/src/resolvers/TestExecutionScreenshot.ts
+++ b/src/resolvers/TestExecutionScreenshot.ts
@@ -14,9 +14,8 @@ const resolvers: TestExecutionScreenshotResolvers = {
     },
     async url({ id }, _args, { dataSources }) {
         const bucketName = config.AWS_BUCKET_NAME;
-        const bucketPath = config.AWS_BUCKET_PATH || '';
         const event = await dataSources.screenshot.getById(id);
-        const url = await S3Service.getSignedUrl(bucketName, `${bucketPath}${event.fileName}`);
+        const url = await S3Service.getSignedUrl(bucketName, `${event.fileName}`);
 
         return {
             __typename: 'SignedURL',


### PR DESCRIPTION
Changes:
- Additional erroneous `bucketPath` variable removed from `TestExecutionScreenshot` resolver.
- Fix indentation in other `datasources` files.

_Before / after fix screen recordings shown below._

Before:

https://github.com/testerloop/testerloop-server/assets/4661986/8f78666d-6752-41af-8c71-47aa5363c9b1

After:


https://github.com/testerloop/testerloop-server/assets/4661986/c87c13d0-fa9b-4309-9e03-37616dd14176

