### PR TITLE
[FIX] Allow nullable snapshots

### DIFF
--- a/src/maps/mapStepData.ts
+++ b/src/maps/mapStepData.ts
@@ -26,7 +26,7 @@ const OptionsSchema = z.object({
     url: z.string(),
     wallClockStartedAt: z.string(),
     ended: z.boolean(),
-    snapshotID: z.number(),
+    snapshotID: z.optional(z.number()),
     group: z.optional(z.string()),
     err: z.optional(ErrorSchema)
   });

--- a/src/resolvers/CommandEvent.ts
+++ b/src/resolvers/CommandEvent.ts
@@ -12,7 +12,10 @@ const resolvers: CommandEventResolvers = {
     async previousSnapshot ({ id, at, snapshotID }, _args, { dataSources }) {
         const [runId, requestId, _] = id.split('/');
         const snapshot = await dataSources.snapshot.getById(`${runId}/${requestId}/snapshot/${snapshotID}`);
-        return { 
+        if (!snapshot) {
+            return null;
+        }
+        return {
             __typename: 'TestExecutionSnapshot' as const,
             testExecutionId: `${runId}/${requestId}`,
             at,
@@ -22,6 +25,9 @@ const resolvers: CommandEventResolvers = {
     async nextSnapshot ({ id, until, snapshotID }, _args, { dataSources }) {
         const [runId, requestId, _] = id.split('/');
         const snapshot = await dataSources.snapshot.getById(`${runId}/${requestId}/snapshot/${snapshotID}`);
+        if (!snapshot) {
+            return null;
+        }
         return { 
             __typename: 'TestExecutionSnapshot' as const,
             testExecutionId: `${runId}/${requestId}`,

--- a/src/resolvers/StepEvent.ts
+++ b/src/resolvers/StepEvent.ts
@@ -1,70 +1,78 @@
-import getPaginatedData from "../util/getPaginatedData.js";
-import { encodeId } from "../util/id.js";
-import { GherkinStepKeyword, StepEventResolvers } from "./types/generated.js";
+import getPaginatedData from '../util/getPaginatedData.js';
+import { encodeId } from '../util/id.js';
+import { GherkinStepKeyword, StepEventResolvers } from './types/generated.js';
 
 const resolvers: StepEventResolvers = {
-  id({ _id }) {
-    return encodeId("StepEvent", _id);
-  },
-  async at({ _id }, _args, { dataSources }) {
-    const event = await dataSources.stepEvent.getById(_id);
-    return event.at;
-  },
-  async until({ _id }, _args, { dataSources }) {
-    const event = await dataSources.stepEvent.getById(_id);
-    return event.until;
-  },
-  async status({ _id }, _args, { dataSources }) {
-    const event = await dataSources.stepEvent.getById(_id);
-    return event.status;
-  },
-  async commandChains({ _id }, _args, { dataSources }) {
-    const event = await dataSources.stepEvent.getById(_id);
-    return getPaginatedData(event.commandChains);
-  },
-  async previousSnapshot({ _id, at, snapshotID }, _args, { dataSources }) {
-    const [runId, requestId, _] = _id.split("/");
-    const snapshot = await dataSources.snapshot.getById(
-      `${runId}/${requestId}/snapshot/${snapshotID}`
-    );
-    return {
-      __typename: "TestExecutionSnapshot" as const,
-      testExecutionId: `${runId}/${requestId}`,
-      at,
-      dom: snapshot.beforeBody,
-    };
-  },
-  async nextSnapshot({ _id, until, snapshotID }, _args, { dataSources }) {
-    const [runId, requestId, _] = _id.split("/");
-    const snapshot = await dataSources.snapshot.getById(
-      `${runId}/${requestId}/snapshot/${snapshotID}`
-    );
-    return {
-      __typename: "TestExecutionSnapshot" as const,
-      testExecutionId: `${runId}/${requestId}`,
-      at: until,
-      dom: snapshot.afterBody,
-    };
-  },
-  async definition({ _id }, _args, { dataSources }) {
-    const event = await dataSources.stepEvent.getById(_id);
-    return {
-      __typename: "StepDefinition",
-      description: event.message,
-      keyword: event.name,
-    };
-  },
-  async testExecution({ _id }, _args) {
-    const [runId, _] = _id.split("/");
-    return {
-      __typename: "TestExecution",
-      id: _id,
-      testRun: {
-        __typename: "TestRun",
-        id: runId,
-      },
-    };
-  },
+    id({ _id }) {
+        return encodeId('StepEvent', _id);
+    },
+    async at({ _id }, _args, { dataSources }) {
+        const event = await dataSources.stepEvent.getById(_id);
+        return event.at;
+    },
+    async until({ _id }, _args, { dataSources }) {
+        const event = await dataSources.stepEvent.getById(_id);
+        return event.until;
+    },
+    async status({ _id }, _args, { dataSources }) {
+        const event = await dataSources.stepEvent.getById(_id);
+        return event.status;
+    },
+    async commandChains({ _id }, _args, { dataSources }) {
+        const event = await dataSources.stepEvent.getById(_id);
+        return getPaginatedData(event.commandChains);
+    },
+    async previousSnapshot({ _id, at, snapshotID }, _args, { dataSources }) {
+        const [runId, requestId, _] = _id.split('/');
+        const snapshot = await dataSources.snapshot.getById(`${runId}/${requestId}/snapshot/${snapshotID}`);
+
+        if (!snapshot) {
+            return null;
+        }
+
+        return {
+            __typename: 'TestExecutionSnapshot' as const,
+            testExecutionId: `${runId}/${requestId}`,
+            at,
+            dom: snapshot.beforeBody,
+        };
+    },
+
+    async nextSnapshot({ _id, until, snapshotID }, _args, { dataSources }) {
+        const [runId, requestId, _] = _id.split('/');
+        const snapshot = await dataSources.snapshot.getById(`${runId}/${requestId}/snapshot/${snapshotID}`);
+
+        if (!snapshot) {
+            return null;
+        }
+
+        return {
+            __typename: 'TestExecutionSnapshot' as const,
+            testExecutionId: `${runId}/${requestId}`,
+            at: until,
+            dom: snapshot.afterBody,
+        };
+    },
+
+    async definition({ _id }, _args, { dataSources }) {
+        const event = await dataSources.stepEvent.getById(_id);
+        return {
+            __typename: 'StepDefinition',
+            description: event.message,
+            keyword: event.name,
+        };
+    },
+    async testExecution({ _id }, _args) {
+        const [runId, _] = _id.split('/');
+        return {
+            __typename: 'TestExecution',
+            id: _id,
+            testRun: {
+                __typename: 'TestRun',
+                id: runId,
+            },
+        };
+    },
 };
 
 export default resolvers;

--- a/src/resolvers/types/generated.ts
+++ b/src/resolvers/types/generated.ts
@@ -76,8 +76,8 @@ export type CommandEvent = Event & IntervalEvent & Node & SnapshotEvent & TestEx
   readonly error: Maybe<CommandEventError>;
   readonly id: Scalars['ID'];
   readonly name: Scalars['String'];
-  readonly nextSnapshot: TestExecutionSnapshot;
-  readonly previousSnapshot: TestExecutionSnapshot;
+  readonly nextSnapshot: Maybe<TestExecutionSnapshot>;
+  readonly previousSnapshot: Maybe<TestExecutionSnapshot>;
   readonly status: CommandEventStatus;
   readonly testExecution: TestExecution;
   readonly until: Scalars['DateTime'];
@@ -548,8 +548,8 @@ export type SignedUrl = {
 
 export type SnapshotEvent = {
   readonly at: Scalars['DateTime'];
-  readonly nextSnapshot: TestExecutionSnapshot;
-  readonly previousSnapshot: TestExecutionSnapshot;
+  readonly nextSnapshot: Maybe<TestExecutionSnapshot>;
+  readonly previousSnapshot: Maybe<TestExecutionSnapshot>;
 };
 
 export type SourceCodeManagementRepository = {
@@ -593,8 +593,8 @@ export type StepEvent = Event & IntervalEvent & Node & SnapshotEvent & TestExecu
   readonly commandChains: CommandChainEventConnection;
   readonly definition: StepDefinition;
   readonly id: Scalars['ID'];
-  readonly nextSnapshot: TestExecutionSnapshot;
-  readonly previousSnapshot: TestExecutionSnapshot;
+  readonly nextSnapshot: Maybe<TestExecutionSnapshot>;
+  readonly previousSnapshot: Maybe<TestExecutionSnapshot>;
   readonly status: CommandEventStatus;
   readonly testExecution: TestExecution;
   readonly until: Scalars['DateTime'];
@@ -1065,8 +1065,8 @@ export type CommandEventResolvers<ContextType = Context, ParentType extends Reso
   error: Resolver<Maybe<ResolversTypes['CommandEventError']>, ParentType, ContextType>;
   id: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   name: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  nextSnapshot: Resolver<ResolversTypes['TestExecutionSnapshot'], ParentType, ContextType>;
-  previousSnapshot: Resolver<ResolversTypes['TestExecutionSnapshot'], ParentType, ContextType>;
+  nextSnapshot: Resolver<Maybe<ResolversTypes['TestExecutionSnapshot']>, ParentType, ContextType>;
+  previousSnapshot: Resolver<Maybe<ResolversTypes['TestExecutionSnapshot']>, ParentType, ContextType>;
   status: Resolver<ResolversTypes['CommandEventStatus'], ParentType, ContextType>;
   testExecution: Resolver<ResolversTypes['TestExecution'], ParentType, ContextType>;
   until: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
@@ -1428,8 +1428,8 @@ export type StepEventResolvers<ContextType = Context, ParentType extends Resolve
   commandChains: Resolver<ResolversTypes['CommandChainEventConnection'], ParentType, ContextType>;
   definition: Resolver<ResolversTypes['StepDefinition'], ParentType, ContextType>;
   id: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  nextSnapshot: Resolver<ResolversTypes['TestExecutionSnapshot'], ParentType, ContextType>;
-  previousSnapshot: Resolver<ResolversTypes['TestExecutionSnapshot'], ParentType, ContextType>;
+  nextSnapshot: Resolver<Maybe<ResolversTypes['TestExecutionSnapshot']>, ParentType, ContextType>;
+  previousSnapshot: Resolver<Maybe<ResolversTypes['TestExecutionSnapshot']>, ParentType, ContextType>;
   status: Resolver<ResolversTypes['CommandEventStatus'], ParentType, ContextType>;
   testExecution: Resolver<ResolversTypes['TestExecution'], ParentType, ContextType>;
   until: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;

--- a/src/schema/execution/bdd/StepEvent.graphql
+++ b/src/schema/execution/bdd/StepEvent.graphql
@@ -5,8 +5,8 @@ type StepEvent implements Node & Event & IntervalEvent & TestExecutionEvent & Sn
   commandChains: CommandChainEventConnection!
   definition: StepDefinition!
   status: CommandEventStatus!
-  previousSnapshot: TestExecutionSnapshot!
-  nextSnapshot: TestExecutionSnapshot!
+  previousSnapshot: TestExecutionSnapshot
+  nextSnapshot: TestExecutionSnapshot
   testExecution: TestExecution!
 }
 

--- a/src/schema/execution/command/CommandEvent.graphql
+++ b/src/schema/execution/command/CommandEvent.graphql
@@ -14,8 +14,8 @@ type CommandEvent implements Node & Event & IntervalEvent & TestExecutionEvent &
   # Needs SourceCode stuff from Summary Panel Schema.
   # source: SourceCodeManagementRevisionFileLine!
   testExecution: TestExecution!
-  previousSnapshot: TestExecutionSnapshot!
-  nextSnapshot: TestExecutionSnapshot!
+  previousSnapshot: TestExecutionSnapshot
+  nextSnapshot: TestExecutionSnapshot
 }
 
 type CommandEventConnection {

--- a/src/schema/execution/snapshots/SnapshotEvent.graphql
+++ b/src/schema/execution/snapshots/SnapshotEvent.graphql
@@ -1,5 +1,5 @@
 interface SnapshotEvent implements Event {
     at: DateTime!
-    previousSnapshot: TestExecutionSnapshot!
-    nextSnapshot: TestExecutionSnapshot!
+    previousSnapshot: TestExecutionSnapshot
+    nextSnapshot: TestExecutionSnapshot
 }


### PR DESCRIPTION
As suggested by Oliver - allowing nullable snapshot fields on the backend (frontend PR to be submitted in a moment) to avoid errors when navigating to passing tests without a `snapshotId` in the final step of the `commandChain`

Avoids the below error 

![image](https://github.com/testerloop/testerloop-server/assets/4661986/f9fe2d1f-30ce-47e1-856a-86b4d62bcb93)
