### PR TITLE
[Fix] make _queued optional in HttpNetworkTimingsSchema

### DIFF
--- a/src/maps/mapNetworkEvents.ts
+++ b/src/maps/mapNetworkEvents.ts
@@ -51,7 +51,7 @@ const HttpNetworkResponseSchema = z.object({
 
 
 const HttpNetworkTimingsSchema = z.object({
-    _queued: z.number(),
+    _queued: z.optional(z.number()),
     blocked: z.number(),
     connect: z.number(),
     ssl: z.number(),


### PR DESCRIPTION
Fix for: https://trello.com/c/e52ajLeN/389-bug-error-occurs-when-opening-testerloop-link-for-specific-test

See below - `_queued` value was missing at `log.entries[53].timings` in the  `network-events.har` file of this particular execution, so have made the field optional in the file schema for now in case this crops up again.

<img width="465" alt="Screenshot 2023-06-22 at 22 03 25" src="https://github.com/testerloop/testerloop-server/assets/4661986/5aa1936a-2290-4b85-9458-77f5e01bcdd7">
