### PR TITLE
add regex check for ypresssteps

### DIFF
--- a/src/maps/mapStepData.ts
+++ b/src/maps/mapStepData.ts
@@ -50,8 +50,8 @@ const mapStepData = (steps: unknown) => {
             if (options.err?.codeFrame?.relativeFile) {
                 options.err.codeFrame.relativeFile =
                     options.err.codeFrame.relativeFile.replace(
-                        /^ypresssteps/,
-                        'cypress/steps'
+                        /^ypress/,
+                        'cypress/'
                     );
             }
             return options;


### PR DESCRIPTION
For ticket: https://trello.com/c/ixdDaOVo/327-bug-error-occurs-when-running-tests-throughs-ecs-for-resultsjson

In the app:
![image](https://github.com/testerloop/testerloop-server/assets/4661986/2357a95f-4b52-4b3b-b2cf-94f78a7dd398)

Correct link:
![image](https://github.com/testerloop/testerloop-server/assets/4661986/719e4098-f965-4020-9856-03d7a827f336)

